### PR TITLE
Resolves #31

### DIFF
--- a/getTable.py
+++ b/getTable.py
@@ -140,7 +140,7 @@ def discordMain():
 
     for row in data:
       if row[1]=='Arsenal':
-        row[0]="‣ "+row[0]
+        row[0]="* "+row[0]
         # row.insert(0,"►")
         # row.append("◄")
       


### PR DESCRIPTION
Using a non-standard ASCII character presents issues while rendering on discord using '```'. Also, renders differently on phone and desktop. So, replaced the arrow with a '*'.