### PR TITLE
Disable light mode for league tables, and update requirements.txt file

### DIFF
--- a/cogs/tables.py
+++ b/cogs/tables.py
@@ -25,8 +25,11 @@ class Tables(commands.Cog):
         # Check if (w)hite or (l)ight, else use dark mode
         light_mode = background.startswith('l') or background.startswith('w')
 
-        bg_colour = (255, 255, 255) if light_mode else (47, 49, 54)
-        font_colour = (0, 0, 0) if light_mode else (255, 255, 255)
+        if (light_mode):
+            return await ctx.send(f"Light mode is not allowed, you spud.")
+
+        bg_colour = (47, 49, 54)
+        font_colour = (255, 255, 255)
 
         img = Image.new('RGB', (1130, 840), bg_colour)
         d = ImageDraw.Draw(img)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
-discord~=1.7.3
-bs4~=0.0.1
-datetime~=4.3
-tabulate~=0.8.9
-Pillow~=9.0.0
-pandas~=1.4.0
+discord==1.7.3
+discord.py==1.7.3
+bs4==0.0.1
+datetime==4.3
+tabulate==0.8.9
+Pillow==9.0.0
+pandas==1.4.0
+lxml==4.9.2
+fotmob==0.0.2
 
-requests~=2.27.1
-beautifulsoup4~=4.10.0
+requests==2.27.1
+beautifulsoup4==4.10.0


### PR DESCRIPTION
- discord.py > 1.7.3 introduces breaking changes, so I am adding specific versions of the packages to use to avoid confusion.

- There were a couple of missing packages from the file too, added them (lxml, fotmob).

- Disabling light mode since it's ugly, and the only user of it was banned (Blair)

Screenshots where I tested the changes: https://discord.com/channels/193393364819771392/617026340297900032/1093327968488652830