### PR TITLE
Auto-delete discord invites

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 import sys
 
 import discord
 from discord.ext import commands
+
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 
 if not os.path.isfile("config.json"):
     sys.exit("'Config file not found! Please add it and try again.")
@@ -16,6 +19,7 @@ intents.members = True
 intents.messages = True
 intents.message_content = True
 
+
 class Bot(commands.Bot):
     def __init__(self):
         super().__init__(command_prefix=config['prefix'], intents=intents)
@@ -24,21 +28,21 @@ class Bot(commands.Bot):
         await bot.wait_until_ready()
         await bot.tree.sync()
         await bot.change_presence(activity=discord.Game(name='Wengerball'))
-        print('Successfully synced applications commands')
-        print(f'Connected as {bot.user}')
+        logging.info('Successfully synced applications commands')
+        logging.info(f'Connected as {bot.user}')
 
     async def setup_hook(self):
         for filename in os.listdir("./cogs"):
             if filename.endswith(".py"):
                 try:
                     await bot.load_extension(f"cogs.{filename[:-3]}")
-                    print(f"Loaded {filename}")
+                    logging.info(f"Loaded {filename}")
                 except Exception as e:
-                    print(f"Failed to load {filename}")
-                    print(f"[ERROR] {e}")
+                    logging.error(f"Failed to load {filename}")
+                    logging.error(f"[ERROR] {e}")
 
         self.loop.create_task(self.startup())
 
+
 bot = Bot()
 bot.run(config["token"])
-

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -10,7 +10,7 @@ from discord.ext import commands
 
 logger = logging.getLogger(__name__)
 
-mod_roles = ["The Boss"]
+mod_roles = ['Gaffer', 'Coach', 'Captain']
 
 
 def is_moderator(user):

--- a/cogs/twitter_link_fixer.py
+++ b/cogs/twitter_link_fixer.py
@@ -1,7 +1,10 @@
+import logging
 import re
 from urllib.parse import urlparse
 
 from discord.ext import commands
+
+logger = logging.getLogger(__name__)
 
 
 class TwitterLinkFixerCog(commands.Cog):
@@ -21,9 +24,15 @@ class TwitterLinkFixerCog(commands.Cog):
         if message.author.bot:
             return
         # Limit fixing Tweets to first found link, to prevent potential spam
-        twitter_url = self.find_twitter_urls(message.content.lower())[0]
+        try:
+            twitter_url = self.find_twitter_urls(message.content.lower())[0]
+        except IndexError:
+            logger.info(f'{message.content} is not a twitter link')
+            twitter_url = ''
         if twitter_url:
             await message.edit(suppress=True)
             await message.reply(f"Fx'ed that for you! {self.rewrite_url(twitter_url)}", mention_author=False)
+
+
 async def setup(bot):
     await bot.add_cog(TwitterLinkFixerCog(bot))


### PR DESCRIPTION
The main purpose of this PR is to add code to the moderation cog `moderation.py` that checks if the message contains a discord invite, if so it deletes it. For the time being I'm deleting indiscriminately. At some point we could maybe adjust this to either have a whitelist or blacklist. That said, I also added code to ignore the invite restriction if you're a mod.

In addition to that change I also updated the `twitter_link_fixer.py` to stop crashing if the message isn't a twitter link. Instead we catch the error and continue on.

Finally, I've started the process of switching from print statements to logging. As files are touched they should also be updated.